### PR TITLE
Enable Service Provider Relocation (#17)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,9 @@
                             <shadedPattern>${shade.prefix}.avroshaded</shadedPattern>
                         </relocation>
                     </relocations>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                    </transformers>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
Schema Registry Client's basic HTTP Authentication support is
implemented through a ServiceProvider.  Without handling the fact that
relocating the schema client also relocates the service implementations,
no implementations are found when the client attempts to find a strategy
that matches an authentication source type specified through
basic.auth.credentials.source...